### PR TITLE
Installation scripts: fix 32 bits output directory

### DIFF
--- a/install32.sh
+++ b/install32.sh
@@ -40,7 +40,7 @@ if [ -d "$LIBDIR" ]; then
 	sudo rm -rf $LIBDIR/modules
 fi
 
-sudo cp output/uImage $BOOTDIR
-sudo cp output/*.dtb $BOOTDIR
-sudo cp -r output/lib/modules $LIBDIR
+sudo cp output32/uImage $BOOTDIR
+sudo cp output32/*.dtb $BOOTDIR
+sudo cp -r output32/lib/modules $LIBDIR
 sync


### PR DESCRIPTION
The `install32.sh` script was copying the output from the 64 bit compilation. This PR fixes this issue by altering the directory reference in the script.