### PR TITLE
Installation scripts: copy config.json to BOOT directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ fi
 if [ -d "$BOOTDIR" ]; then
 	sudo rm -f $BOOTDIR/*.dtb
 	sudo rm -f $BOOTDIR/Image
+	sudo rm -f $BOOTDIR/config.json
 else
 	sudo mkdir $BOOTDIR
 fi
@@ -32,5 +33,6 @@ fi
 
 sudo cp output/Image $BOOTDIR
 sudo cp output/*.dtb $BOOTDIR
+sudo cp config.json $BOOTDIR
 sudo cp -r output/lib/modules $LIBDIR
 sync


### PR DESCRIPTION
The file `config.json` wasn't removed and copied into the BOOT directory with the installation script. This PR fixes that.